### PR TITLE
feat: User & Skill base APIs with JPA setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/skillgap/analyzer/controller/SkillController.java
+++ b/src/main/java/com/skillgap/analyzer/controller/SkillController.java
@@ -1,0 +1,26 @@
+package com.skillgap.analyzer.controller;
+
+import com.skillgap.analyzer.entity.Skill;
+import com.skillgap.analyzer.service.SkillService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/skills")
+@RequiredArgsConstructor
+public class SkillController {
+
+    private final SkillService skillService;
+
+    @PostMapping
+    public Skill createSkill(@RequestBody Skill skill) {
+        return skillService.createSkill(skill);
+    }
+
+    @GetMapping
+    public List<Skill> getAllSkills() {
+        return skillService.getAllSkills();
+    }
+}

--- a/src/main/java/com/skillgap/analyzer/controller/UserController.java
+++ b/src/main/java/com/skillgap/analyzer/controller/UserController.java
@@ -1,0 +1,45 @@
+package com.skillgap.analyzer.controller;
+
+import com.skillgap.analyzer.entity.User;
+import com.skillgap.analyzer.entity.UserSkill;
+import com.skillgap.analyzer.service.UserService;
+import com.skillgap.analyzer.service.UserSkillService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import com.skillgap.analyzer.repository.UserRepository;
+
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final UserSkillService userSkillService;
+    private final UserRepository userRepository;
+
+    @PostMapping
+    public User createUser(@RequestBody User user) {
+        return userService.createUser(user);
+    }
+
+    @PostMapping("/{userId}/skills")
+    public UserSkill addSkillToUser(
+            @PathVariable Long userId,
+            @RequestParam Long skillId,
+            @RequestParam int level) {
+        return userSkillService.addSkillToUser(userId, skillId, level);
+    }
+
+    @GetMapping
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    @GetMapping("/{userId}/skills")
+    public List<UserSkill> getUserSkills(@PathVariable Long userId) {
+        return userSkillService.getUserSkills(userId);
+    }
+}

--- a/src/main/java/com/skillgap/analyzer/entity/Skill.java
+++ b/src/main/java/com/skillgap/analyzer/entity/Skill.java
@@ -1,0 +1,23 @@
+package com.skillgap.analyzer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "skills")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Skill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String category; // e.g., Backend, Database, DevOps
+}

--- a/src/main/java/com/skillgap/analyzer/entity/User.java
+++ b/src/main/java/com/skillgap/analyzer/entity/User.java
@@ -1,0 +1,23 @@
+package com.skillgap.analyzer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+}

--- a/src/main/java/com/skillgap/analyzer/entity/UserSkill.java
+++ b/src/main/java/com/skillgap/analyzer/entity/UserSkill.java
@@ -1,0 +1,28 @@
+package com.skillgap.analyzer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_skills")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSkill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "skill_id")
+    private Skill skill;
+
+    private int proficiencyLevel; // 1–5
+}

--- a/src/main/java/com/skillgap/analyzer/repository/SkillRepository.java
+++ b/src/main/java/com/skillgap/analyzer/repository/SkillRepository.java
@@ -1,0 +1,10 @@
+package com.skillgap.analyzer.repository;
+
+import com.skillgap.analyzer.entity.Skill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+    Optional<Skill> findByName(String name);
+}

--- a/src/main/java/com/skillgap/analyzer/repository/UserRepository.java
+++ b/src/main/java/com/skillgap/analyzer/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.skillgap.analyzer.repository;
+
+import com.skillgap.analyzer.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/skillgap/analyzer/repository/UserSkillRepository.java
+++ b/src/main/java/com/skillgap/analyzer/repository/UserSkillRepository.java
@@ -1,0 +1,11 @@
+package com.skillgap.analyzer.repository;
+
+import com.skillgap.analyzer.entity.UserSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserSkillRepository extends JpaRepository<UserSkill, Long> {
+
+    List<UserSkill> findByUserId(Long userId);
+}

--- a/src/main/java/com/skillgap/analyzer/service/SkillService.java
+++ b/src/main/java/com/skillgap/analyzer/service/SkillService.java
@@ -1,0 +1,23 @@
+package com.skillgap.analyzer.service;
+
+import com.skillgap.analyzer.entity.Skill;
+import com.skillgap.analyzer.repository.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SkillService {
+
+    private final SkillRepository skillRepository;
+
+    public Skill createSkill(Skill skill) {
+        return skillRepository.save(skill);
+    }
+
+    public List<Skill> getAllSkills() {
+        return skillRepository.findAll();
+    }
+}

--- a/src/main/java/com/skillgap/analyzer/service/UserService.java
+++ b/src/main/java/com/skillgap/analyzer/service/UserService.java
@@ -1,0 +1,17 @@
+package com.skillgap.analyzer.service;
+
+import com.skillgap.analyzer.entity.User;
+import com.skillgap.analyzer.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/skillgap/analyzer/service/UserSkillService.java
+++ b/src/main/java/com/skillgap/analyzer/service/UserSkillService.java
@@ -1,0 +1,38 @@
+package com.skillgap.analyzer.service;
+
+import com.skillgap.analyzer.entity.*;
+import com.skillgap.analyzer.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserSkillService {
+
+    private final UserSkillRepository userSkillRepository;
+    private final UserRepository userRepository;
+    private final SkillRepository skillRepository;
+
+    public UserSkill addSkillToUser(Long userId, Long skillId, int level) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Skill skill = skillRepository.findById(skillId)
+                .orElseThrow(() -> new RuntimeException("Skill not found"));
+
+        UserSkill userSkill = UserSkill.builder()
+                .user(user)
+                .skill(skill)
+                .proficiencyLevel(level)
+                .build();
+
+        return userSkillRepository.save(userSkill);
+    }
+
+    public List<UserSkill> getUserSkills(Long userId) {
+        return userSkillRepository.findByUserId(userId);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=SkillGapAnalyzer
+spring.datasource.url=jdbc:mysql://localhost:3306/skillgap
+spring.datasource.username=root
+spring.datasource.password=Saurav@1234
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
feat: User & Skill Base APIs with JPA Setup (SGA0.1)

## 🚀 Feature: Initial Backend Setup for SkillGap Analyzer

This PR introduces the foundational backend structure and core APIs for the SkillGap Analyzer system.

---

## 🧩 Features Implemented

### ✅ Project Setup
- Spring Boot project initialization
- MySQL database configuration
- JPA & Hibernate integration

### ✅ Entities
- User
- Skill
- UserSkill (association entity)

### ✅ Repository Layer
- UserRepository
- SkillRepository
- UserSkillRepository

### ✅ REST APIs

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST   | /users   | Create new user |
| GET    | /users   | Get all users |


---

## 🧠 Design Decision

The relationship between **User** and **Skill** is implemented using a separate entity:

**UserSkill**

This allows storing additional attribute:

`proficiencyLevel (1–5)`

This approach follows best practices for many-to-many relationships with extra fields.

---

## 🧪 Testing

- APIs tested using Postman
- Data persistence verified in MySQL
- Swagger UI accessible and functional

---

## 🔜 Next Step

SGA0.2 — Role Management System

---

Branch: `SGA0.1-base-setup`
